### PR TITLE
CS Fixers for controller migration

### DIFF
--- a/bin/pimcore.php
+++ b/bin/pimcore.php
@@ -46,6 +46,7 @@ $application->addCommands([
     new Command\Pimcore5\UpdateDbReferencesCommand(),
     new Command\Pimcore5\RenameViewsCommand(),
     new Command\Pimcore5\FixViewsCommand(),
+    new Command\Pimcore5\FixControllersCommand(),
     new Command\Pimcore5\FixConfigCommand(),
 ]);
 

--- a/src/Cli/Command/Pimcore5/AbstractCsFixerCommand.php
+++ b/src/Cli/Command/Pimcore5/AbstractCsFixerCommand.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Cli\Command\Pimcore5;
+
+use PhpCsFixer\Config;
+use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\Console\Output\ErrorOutput;
+use PhpCsFixer\Console\Output\NullOutput;
+use PhpCsFixer\Console\Output\ProcessOutput;
+use PhpCsFixer\Error\ErrorsManager;
+use PhpCsFixer\Report\ReportSummary;
+use PhpCsFixer\Runner\Runner;
+use Pimcore\CsFixer\Console\ConfigurationResolver;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * Runs PHP-CS-Fixer with our custom ruleset to ease view migration. This command
+ * is heavily inspired by the FixCommand from the PHP-CS-Fixer package.
+ */
+abstract class AbstractCsFixerCommand extends Command
+{
+    // Exit status 1 is reserved for environment constraints not matched.
+    const EXIT_STATUS_FLAG_HAS_INVALID_FILES = 4;
+    const EXIT_STATUS_FLAG_HAS_CHANGED_FILES = 8;
+    const EXIT_STATUS_FLAG_HAS_INVALID_CONFIG = 16;
+    const EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG = 32;
+    const EXIT_STATUS_FLAG_EXCEPTION_IN_APP = 64;
+
+    /**
+     * EventDispatcher instance.
+     *
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    /**
+     * ErrorsManager instance.
+     *
+     * @var ErrorsManager
+     */
+    private $errorsManager;
+
+    /**
+     * Stopwatch instance.
+     *
+     * @var Stopwatch
+     */
+    private $stopwatch;
+
+    /**
+     * Config instance.
+     *
+     * @var ConfigInterface
+     */
+    private $config;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->config          = $this->buildConfig();
+        $this->errorsManager   = new ErrorsManager();
+        $this->eventDispatcher = new EventDispatcher();
+        $this->stopwatch       = new Stopwatch();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(
+                [
+                    new InputArgument('path', InputArgument::REQUIRED, 'The path.'),
+                    new InputOption('path-mode', '', InputOption::VALUE_REQUIRED, 'Specify path mode (can be override or intersection).', 'override'),
+                    new InputOption('allow-risky', '', InputOption::VALUE_REQUIRED, 'Are risky fixers allowed (can be yes or no).'),
+                    new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
+                    new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Does cache should be used (can be yes or no).'),
+                    new InputOption('cache-file', '', InputOption::VALUE_REQUIRED, 'The path to the cache file.'),
+                    new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file.'),
+                    new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
+                    new InputOption('stop-on-violation', '', InputOption::VALUE_NONE, 'Stop execution on first violation.'),
+                    new InputOption('show-progress', '', InputOption::VALUE_REQUIRED, 'Type of progress indicator (none, run-in, or estimating).'),
+                ]
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $verbosity = $output->getVerbosity();
+
+        $resolver = new ConfigurationResolver(
+            $this->config,
+            [
+                'allow-risky'       => $input->getOption('allow-risky'),
+                'dry-run'           => $input->getOption('dry-run'),
+                'path'              => $input->getArgument('path'),
+                'path-mode'         => $input->getOption('path-mode'),
+                'using-cache'       => $input->getOption('using-cache'),
+                'cache-file'        => $input->getOption('cache-file'),
+                'format'            => $input->getOption('format'),
+                'diff'              => $input->getOption('diff'),
+                'stop-on-violation' => $input->getOption('stop-on-violation'),
+                'verbosity'         => $verbosity,
+                'show-progress'     => $input->getOption('show-progress'),
+            ],
+            getcwd()
+        );
+
+        $reporter = $resolver->getReporter();
+
+        $stdErr = $output instanceof ConsoleOutputInterface
+            ? $output->getErrorOutput()
+            : ('txt' === $reporter->getFormat() ? $output : null);
+
+        if (null !== $stdErr) {
+            if (extension_loaded('xdebug')) {
+                $stdErr->writeln(sprintf($stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s', 'You are running the fix command which uses php-cs-fixer with xdebug enabled. This has a major impact on runtime performance.'));
+            }
+
+            if ($resolver->getUsingCache()) {
+                $cacheFile = $resolver->getCacheFile();
+                if (is_file($cacheFile)) {
+                    $stdErr->writeln(sprintf('Using cache file "%s".', $cacheFile));
+                }
+            }
+        }
+
+        $progressType = $resolver->getProgress();
+
+        /** @var Finder $finder */
+        $finder = $resolver->getFinder();
+
+        if ('none' === $progressType || null === $stdErr) {
+            $progressOutput = new NullOutput();
+        } elseif ('run-in' === $progressType) {
+            $progressOutput = new ProcessOutput($stdErr, $this->eventDispatcher, null, null);
+        } else {
+            $finder         = new \ArrayIterator(iterator_to_array($finder));
+            $count          = count($finder);
+            $progressOutput = new ProcessOutput($stdErr, $this->eventDispatcher, $count, $count);
+        }
+
+        $runner = new Runner(
+            $finder,
+            $resolver->getFixers(),
+            $resolver->getDiffer(),
+            'none' !== $progressType ? $this->eventDispatcher : null,
+            $this->errorsManager,
+            $resolver->getLinter(),
+            $resolver->isDryRun(),
+            $resolver->getCacheManager(),
+            $resolver->getDirectory(),
+            $resolver->shouldStopOnViolation()
+        );
+
+        $this->stopwatch->start('fixFiles');
+        $changed = $runner->fix();
+        $this->stopwatch->stop('fixFiles');
+
+        $progressOutput->printLegend();
+
+        $fixEvent = $this->stopwatch->getEvent('fixFiles');
+
+        $reportSummary = new ReportSummary(
+            $changed,
+            $fixEvent->getDuration(),
+            $fixEvent->getMemory(),
+            OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity(),
+            $resolver->isDryRun(),
+            $output->isDecorated()
+        );
+
+        $output->isDecorated()
+            ? $output->write($reporter->generate($reportSummary))
+            : $output->write($reporter->generate($reportSummary), false, OutputInterface::OUTPUT_RAW);
+
+        $invalidErrors   = $this->errorsManager->getInvalidErrors();
+        $exceptionErrors = $this->errorsManager->getExceptionErrors();
+        $lintErrors      = $this->errorsManager->getLintErrors();
+
+        if (null !== $stdErr) {
+            $errorOutput = new ErrorOutput($stdErr);
+
+            if (count($invalidErrors) > 0) {
+                $errorOutput->listErrors('linting before fixing', $invalidErrors);
+            }
+
+            if (count($exceptionErrors) > 0) {
+                $errorOutput->listErrors('fixing', $exceptionErrors);
+            }
+
+            if (count($lintErrors) > 0) {
+                $errorOutput->listErrors('linting after fixing', $lintErrors);
+            }
+        }
+
+        return $this->calculateExitStatus(
+            $resolver->isDryRun(),
+            count($changed) > 0,
+            count($invalidErrors) > 0,
+            count($exceptionErrors) > 0
+        );
+    }
+
+    private function buildConfig(): ConfigInterface
+    {
+        $fixers = $this->getCustomFixers();
+
+        $rules = [];
+        foreach ($fixers as $fixer) {
+            $rules[$fixer->getName()] = true;
+        }
+
+        $config = new Config();
+        $config->setCacheFile('.pimcore_cli.fix.cache');
+        $config->registerCustomFixers($fixers);
+        $config->setRules($rules);
+
+        return $config;
+    }
+
+    /**
+     * Returns custom fixers which should be used for the running command
+     *
+     * @return array
+     */
+    abstract protected function getCustomFixers(): array;
+
+    /**
+     * @param bool $isDryRun
+     * @param bool $hasChangedFiles
+     * @param bool $hasInvalidErrors
+     * @param bool $hasExceptionErrors
+     *
+     * @return int
+     */
+    private function calculateExitStatus($isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors)
+    {
+        $exitStatus = 0;
+
+        if ($isDryRun) {
+            if ($hasChangedFiles) {
+                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_CHANGED_FILES;
+            }
+
+            if ($hasInvalidErrors) {
+                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_INVALID_FILES;
+            }
+        }
+
+        if ($hasExceptionErrors) {
+            $exitStatus |= self::EXIT_STATUS_FLAG_EXCEPTION_IN_APP;
+        }
+
+        return $exitStatus;
+    }
+}

--- a/src/Cli/Command/Pimcore5/FixControllersCommand.php
+++ b/src/Cli/Command/Pimcore5/FixControllersCommand.php
@@ -19,7 +19,7 @@ namespace Pimcore\Cli\Command\Pimcore5;
 
 use Pimcore\CsFixer\Util\FixerResolver;
 
-class FixViewsCommand extends AbstractCsFixerCommand
+class FixControllersCommand extends AbstractCsFixerCommand
 {
     /**
      * @inheritDoc
@@ -27,8 +27,8 @@ class FixViewsCommand extends AbstractCsFixerCommand
     protected function configure()
     {
         $this
-            ->setName('pimcore5:views:fix')
-            ->setDescription('Changes common migration patterns in view files (e.g. strips leading slashes in template() calls)');
+            ->setName('pimcore5:controllers:fix')
+            ->setDescription('Changes common migration patterns in controllers');
 
         parent::configure();
     }
@@ -38,6 +38,6 @@ class FixViewsCommand extends AbstractCsFixerCommand
      */
     protected function getCustomFixers(): array
     {
-        return FixerResolver::getCustomFixers('View');
+        return FixerResolver::getCustomFixers('Controller');
     }
 }

--- a/src/CsFixer/Fixer/AbstractFunctionReferenceFixer.php
+++ b/src/CsFixer/Fixer/AbstractFunctionReferenceFixer.php
@@ -17,6 +17,7 @@ namespace Pimcore\CsFixer\Fixer;
 use PhpCsFixer\AbstractFunctionReferenceFixer as BaseAbstractFunctionReferenceFixer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use Pimcore\CsFixer\Tokenizer\FunctionAnalyzer;
 
 abstract class AbstractFunctionReferenceFixer extends BaseAbstractFunctionReferenceFixer
 {
@@ -27,81 +28,28 @@ abstract class AbstractFunctionReferenceFixer extends BaseAbstractFunctionRefere
      * @param array $sequence
      *
      * @return array
+     *
+     * @deprecated use FunctionAnalyzer instead
      */
     protected function findFunctionCallCandidates(Tokens $tokens, array $sequence)
     {
-        if (count($sequence) === 0) {
-            throw new \InvalidArgumentException('Sequence can\'t be empty!');
-        }
-
-        // add opening parenthesis if missing
-        if ($sequence[count($sequence) - 1] !== '(') {
-            throw new \InvalidArgumentException('Sequence must end in opening parenthesis!');
-        }
-
-        $candidates = [];
-
-        $currIndex = 0;
-        while (null !== $currIndex) {
-            $match = $tokens->findSequence($sequence, $currIndex, $tokens->count() - 1);
-
-            // stop looping if didn't find any new matches
-            if (null === $match) {
-                break;
-            }
-
-            $indexes         = array_keys($match);
-            $openParenthesis = array_pop($indexes);
-
-            $closeParenthesis = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis);
-
-            $candidates[] = [$match, $openParenthesis, $closeParenthesis];
-
-            $currIndex = $openParenthesis + 1;
-            if ($currIndex >= count($tokens) - 1) {
-                break;
-            }
-        }
-
-        return array_reverse($candidates);
+        return (new FunctionAnalyzer())->findFunctionCallCandidates($tokens, $sequence);
     }
 
     /**
      * Extracts tokens for a given argument
      *
      * @param Tokens $tokens
-     * @param array $arguments      The result of getArguments()
-     * @param int $argumentIndex    The index of the argument
+     * @param array $arguments   The result of getArguments()
+     * @param int $argumentIndex The index of the argument
      * @param bool $keepIndex
      *
      * @return array|Token[]
+     *
+     * @deprecated use FunctionAnalyzer instead
      */
     protected function extractArgumentTokens(Tokens $tokens, array $arguments, int $argumentIndex, bool $keepIndex = false): array
     {
-        $indexes = array_keys($arguments);
-
-        if (!isset($indexes[$argumentIndex])) {
-            throw new \InvalidArgumentException(sprintf('Argument at index %d does not exist', $argumentIndex));
-        }
-
-        // arguments is an array indexed by start -> end
-        $startIndex = $indexes[$argumentIndex];
-        $endIndex   = $arguments[$startIndex];
-
-        $argumentTokens = [];
-        for ($i = $startIndex; $i <= $endIndex; $i++) {
-            // ignore leading whitespace tokens
-            if (empty($argumentTokens) && $tokens[$i]->isGivenKind(T_WHITESPACE)) {
-                continue;
-            }
-
-            if ($keepIndex) {
-                $argumentTokens[$i] = $tokens[$i];
-            } else {
-                $argumentTokens[] = $tokens[$i];
-            }
-        }
-
-        return $argumentTokens;
+        return (new FunctionAnalyzer())->extractArgumentTokens($tokens, $arguments, $argumentIndex, $keepIndex);
     }
 }

--- a/src/CsFixer/Fixer/Controller/ActionRequestFixer.php
+++ b/src/CsFixer/Fixer/Controller/ActionRequestFixer.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Pimcore\CsFixer\Fixer\Controller;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use Pimcore\CsFixer\Fixer\Traits\FixerNameTrait;
+
+final class ActionRequestFixer extends AbstractFixer
+{
+    use FixerNameTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Adds a Request $request parameter to controller actions',
+            [new CodeSample('public function fooAction()')]
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports(\SplFileInfo $file)
+    {
+        $expectedExtension = '.php';
+
+        if (!substr($file->getFilename(), -strlen($expectedExtension)) === $expectedExtension) {
+            return false;
+        }
+
+        $baseName = $file->getBasename($expectedExtension);
+        if (!preg_match('/Controller$/', $baseName)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_CLASS);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        for ($index = $tokens->getSize() - 1; $index > 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_CLASS)) {
+                continue;
+            }
+
+            // figure out where the classy starts
+            $classStart = $tokens->getNextTokenOfKind($index, ['{']);
+
+            // figure out where the classy ends
+            $classEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classStart);
+
+            $updated = $this->updateActions($tokens, $tokensAnalyzer, $classStart, $classEnd);
+
+            if ($updated) {
+                $this->addRequestImport($tokens, $classStart);
+            }
+        }
+    }
+
+    /**
+     * Finds all public methods which end in Action and adds a Request $request argument if not already existing. Returns
+     * if an action was updated to further add the namespace import.
+     *
+     * @param Tokens $tokens
+     * @param TokensAnalyzer $tokensAnalyzer
+     * @param int $classStart
+     * @param int $classEnd
+     *
+     * @return bool
+     */
+    private function updateActions(Tokens $tokens, TokensAnalyzer $tokensAnalyzer, int $classStart, int $classEnd): bool
+    {
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
+
+        $updated = false;
+        for ($index = $classEnd; $index > $classStart; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $methodNameToken = $tokens->getNextMeaningfulToken($index);
+            if (null === $methodNameToken) {
+                continue;
+            }
+
+            $methodName = $tokens[$methodNameToken];
+
+            // only update methods ending in Action
+            if (!$methodName->isGivenKind(T_STRING) || !preg_match('/Action$/', $methodName->getContent())) {
+                continue;
+            }
+
+            $attributes = $tokensAnalyzer->getMethodAttributes($index);
+
+            // only update public methods
+            if (!(null === $attributes['visibility'] || T_PUBLIC === $attributes['visibility'])) {
+                continue;
+            }
+
+            // do not touch abstract methods
+            if (true === $attributes['abstract']) {
+                continue;
+            }
+
+            $openParenthesis  = $tokens->getNextTokenOfKind($methodNameToken, ['(']);
+            $closeParenthesis = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis);
+            $arguments        = $argumentsAnalyzer->getArguments($tokens, $openParenthesis, $closeParenthesis);
+
+            $requestNeeded = true;
+            foreach ($arguments as $argument) {
+                if ($tokens[$argument]->getContent() === '$request') {
+                    $requestNeeded = false;
+                }
+            }
+
+            if ($requestNeeded) {
+                $requestArgument = [
+                    new Token([T_STRING, 'Request']),
+                    new Token([T_WHITESPACE, ' ']),
+                    new Token([T_VARIABLE, '$request'])
+                ];
+
+                if (count($arguments) > 0) {
+                    $requestArgument[] = new Token(',');
+                    $requestArgument[] = new Token([T_WHITESPACE, ' ']);
+                }
+
+                $tokens->insertAt($openParenthesis + 1, $requestArgument);
+
+                $updated = true;
+            }
+        }
+
+        return $updated;
+    }
+
+    private function addRequestImport(Tokens $tokens, int $classStart)
+    {
+        $namespaceStart = $this->getNamespaceStart($tokens, $classStart);
+        if (null === $namespaceStart) {
+            return;
+        }
+
+        $importTokens = [
+            new Token([T_WHITESPACE, "\n"]),
+            new Token([T_USE, 'use']),
+            new Token([T_WHITESPACE, ' ']),
+            new Token([T_STRING, 'Symfony']),
+            new Token([T_NS_SEPARATOR, '\\']),
+            new Token([T_STRING, 'Component']),
+            new Token([T_NS_SEPARATOR, '\\']),
+            new Token([T_STRING, 'HttpFoundation']),
+            new Token([T_NS_SEPARATOR, '\\']),
+            new Token([T_STRING, 'Request']),
+            new Token(';')
+        ];
+
+        $uses = $this->getImportUses($tokens, $namespaceStart, $classStart);
+        if (0 === count($uses)) {
+            array_unshift($importTokens, new Token([T_WHITESPACE, "\n"]));
+            $tokens->insertAt($namespaceStart, $importTokens);
+
+            return;
+        }
+
+        $importString = $this->stringifyTokenSequence($importTokens);
+
+        $hasImport      = false;
+        $insertPosition = $namespaceStart;
+        foreach ($uses as $use) {
+            $useString = $this->stringifyTokenSequence($use['use']);
+
+            // simple check if Request was already imported. this will fail for group imports or other
+            // more sophicsticated notations, but handling all cases is overkill
+            if (false !== strpos($useString, 'Symfony\\Component\\HttpFoundation\\Request')) {
+                $hasImport = true;
+                break;
+            }
+
+            $cmp = strcmp($importString, $useString);
+
+            if ($cmp >= 0) {
+                $insertPosition = $use['end'] + 1;
+            } elseif ($cmp < 0) {
+                break;
+            }
+        }
+
+        if (!$hasImport) {
+            $tokens->insertAt($insertPosition, $importTokens);
+        }
+    }
+
+    /**
+     * @param Token[] $tokens
+     *
+     * @return string
+     */
+    private function stringifyTokenSequence(array $tokens): string
+    {
+        $string = '';
+        foreach ($tokens as $token) {
+            $string .= $token->getContent();
+        }
+
+        return trim($string);
+    }
+
+    private function getNamespaceStart(Tokens $tokens, int $classStart)
+    {
+        $namespaceStart = null;
+        for ($i = $classStart; $i >= 0; $i--) {
+            if ($tokens[$i]->isGivenKind(T_NAMESPACE)) {
+                $nextTokenIndex = $tokens->getNextTokenOfKind($i, [';', '{']);
+                if (null !== $nextTokenIndex) {
+                    $namespaceStart = $nextTokenIndex;
+                }
+
+                break;
+            }
+
+            if ($tokens[$i]->isGivenKind(T_OPEN_TAG)) {
+                $namespaceStart = $i;
+                break;
+            }
+        }
+
+        return $namespaceStart;
+    }
+
+    private function getImportUses(Tokens $tokens, int $namespaceStart, int $classStart)
+    {
+        $uses = [];
+        for ($index = $namespaceStart; $index <= $classStart; ++$index) {
+            $token = $tokens[$index];
+
+            if ($token->isGivenKind(T_USE)) {
+                $useEnd = $tokens->getNextTokenOfKind($index, [';']);
+
+                $use = [];
+                for ($i = $index; $i <= $useEnd; $i++) {
+                    $use[] = $tokens[$i];
+                }
+
+                $uses[] = [
+                    'start' => $index,
+                    'end'   => $useEnd,
+                    'use'   => $use,
+                ];
+            }
+        }
+
+        return $uses;
+    }
+}

--- a/src/CsFixer/Fixer/Controller/ActionRequestFixer.php
+++ b/src/CsFixer/Fixer/Controller/ActionRequestFixer.php
@@ -46,6 +46,11 @@ final class ActionRequestFixer extends AbstractFixer
                 continue;
             }
 
+            $className = $tokens->getNextMeaningfulToken($index);
+            if (!$className || !$this->isValidControllerName($tokens[$className]->getContent())) {
+                continue;
+            }
+
             // figure out where the classy starts
             $classStart = $tokens->getNextTokenOfKind($index, ['{']);
 

--- a/src/CsFixer/Fixer/Controller/ControllerBaseClassFixer.php
+++ b/src/CsFixer/Fixer/Controller/ControllerBaseClassFixer.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Pimcore\CsFixer\Fixer\Controller;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use Pimcore\CsFixer\Fixer\Traits\FixerNameTrait;
+use Pimcore\CsFixer\Fixer\Traits\SupportsControllerTrait;
+use Pimcore\CsFixer\Tokenizer\ImportsModifier;
+
+final class ControllerBaseClassFixer extends AbstractFixer
+{
+    use FixerNameTrait;
+    use SupportsControllerTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Changes controller base class to FrontendController',
+            [new CodeSample('class TestController extends Website_Controller_Action {}')]
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_CLASS);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $importsModifier = new ImportsModifier($tokens);
+
+        $classIndexes = [];
+        for ($index = $tokens->getSize() - 1; $index > 0; --$index) {
+            if ($tokens[$index]->isGivenKind(T_CLASS)) {
+                $classIndexes[] = $index;
+            }
+        }
+
+        foreach ($classIndexes as $index) {
+            $className = $tokens->getNextMeaningfulToken($index);
+            if (!$className || !$this->isValidControllerName($tokens[$className]->getContent())) {
+                continue;
+            }
+
+            // figure out where the classy starts
+            $classStart = $tokens->getNextTokenOfKind($index, ['{']);
+
+            // back up class definition to keep a reference to any class hierarchies
+            $backup = $this->backupClassDefinition($tokens, $index, $classStart);
+
+            if ($this->updateClassDefinition($tokens, $className, $classStart)) {
+                // insert backup as comment
+                $tokens->insertAt($backup[0], [
+                    new Token([T_COMMENT, $backup[1]]),
+                    new Token([T_WHITESPACE, "\n"])
+                ]);
+
+                // make sure the FrontendController is imported
+                $importsModifier->addImport($classStart, 'Pimcore\Controller\FrontendController');
+            }
+        }
+    }
+
+    /**
+     * Change extends clause to FrontendController or add an extend if not existing yet
+     *
+     * @param Tokens $tokens
+     * @param int $className
+     * @param int $classStart
+     *
+     * @return bool
+     */
+    private function updateClassDefinition(Tokens $tokens, int $className, int $classStart)
+    {
+        $extends = null;
+        for ($i = $className; $i < $classStart; ++$i) {
+            if ($tokens[$i]->isGivenKind(T_EXTENDS)) {
+                $extends = $i;
+                break;
+            }
+        }
+
+        if (null !== $extends) {
+            $parentClass = $tokens->getNextMeaningfulToken($extends);
+
+            // already set - abort
+            if ($tokens[$parentClass]->getContent() === 'FrontendController') {
+                return false;
+            }
+
+            $tokens->offsetSet($parentClass, new Token([T_STRING, 'FrontendController']));
+        } else {
+            $tokens->insertAt($className + 1, [
+                new Token([T_WHITESPACE, ' ']),
+                new Token([T_EXTENDS, 'extends']),
+                new Token([T_STRING, 'FrontendController'])
+            ]);
+        }
+
+        return true;
+    }
+
+    /**
+     * Backup class definition as comment
+     *
+     * @param Tokens $tokens
+     * @param int $classIndex
+     * @param int $classStart
+     *
+     * @return array
+     */
+    private function backupClassDefinition(Tokens $tokens, int $classIndex, int $classStart)
+    {
+        $startIndex = $classIndex;
+
+        $previousToken = $tokens->getPrevMeaningfulToken($classIndex);
+        if ($tokens[$previousToken]->isGivenKind(T_FINAL)) {
+            $startIndex = $previousToken;
+        }
+
+        if (!$this->isNewlineToken($tokens[$startIndex - 1])) {
+            // no newline before [final] class Foo - abort here
+            throw new \UnexpectedValueException(sprintf(
+                'Expected a newline before class definition but got "%s"',
+                $tokens[$startIndex - 1]->getName()
+            ));
+        }
+
+        $comment = '// ';
+        for ($k = $startIndex; $k <= $classStart - 1; $k++) {
+            $comment .= str_replace("\n", ' ', $tokens[$k]->getContent());
+        }
+
+        // remove extra whitespace
+        $comment = preg_replace('/ +/', ' ', $comment);
+        $comment = trim($comment);
+
+        return [
+            $startIndex,
+            $comment
+        ];
+    }
+
+    private function isNewlineToken(Token $token): bool
+    {
+        return ($token->isWhitespace() && false !== strpos($token->getContent(), "\n"));
+    }
+}

--- a/src/CsFixer/Fixer/Controller/ControllerBaseClassFixer.php
+++ b/src/CsFixer/Fixer/Controller/ControllerBaseClassFixer.php
@@ -153,6 +153,6 @@ final class ControllerBaseClassFixer extends AbstractFixer
 
     private function isNewlineToken(Token $token): bool
     {
-        return ($token->isWhitespace() && false !== strpos($token->getContent(), "\n"));
+        return $token->isWhitespace() && false !== strpos($token->getContent(), "\n");
     }
 }

--- a/src/CsFixer/Fixer/Controller/ControllerGetParamFixer.php
+++ b/src/CsFixer/Fixer/Controller/ControllerGetParamFixer.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Pimcore\CsFixer\Fixer\Controller;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use Pimcore\CsFixer\Fixer\Traits\FixerNameTrait;
+use Pimcore\CsFixer\Fixer\Traits\SupportsControllerTrait;
+use Pimcore\CsFixer\Tokenizer\FunctionAnalyzer;
+
+final class ControllerGetParamFixer extends AbstractFixer
+{
+    use FixerNameTrait;
+    use SupportsControllerTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Change calls to $this->getParam() to $request->get()',
+            [new CodeSample('<?php $this->getParam()')]
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return
+            $tokens->isTokenKindFound(T_CLASS)
+            && $tokens->isTokenKindFound(T_VARIABLE)
+            && $tokens->isTokenKindFound(T_OBJECT_OPERATOR)
+            && $tokens->isTokenKindFound(T_CONSTANT_ENCAPSED_STRING);
+    }
+
+    protected function getSequence(): array
+    {
+        return [
+            [T_VARIABLE, '$this'],
+            [T_OBJECT_OPERATOR, '->'],
+            [T_STRING, 'getParam'],
+            '('
+        ];
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        for ($index = $tokens->getSize() - 1; $index > 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_CLASS)) {
+                continue;
+            }
+
+            $className = $tokens->getNextMeaningfulToken($index);
+            if (!$className || !$this->isValidControllerName($tokens[$className]->getContent())) {
+                continue;
+            }
+
+            $classStart = $tokens->getNextTokenOfKind($index, ['{']);
+            $classEnd   = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classStart);
+
+            $this->processClass($tokens, $tokensAnalyzer, $classStart, $classEnd);
+        }
+    }
+
+    private function processClass(Tokens $tokens, TokensAnalyzer $tokensAnalyzer, int $classStart, int $classEnd)
+    {
+        for ($index = $classEnd; $index > $classStart; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $methodNameToken = $tokens->getNextMeaningfulToken($index);
+            if (null === $methodNameToken) {
+                continue;
+            }
+
+            $methodName = $tokens[$methodNameToken];
+
+            // only update methods ending in Action
+            if (!$methodName->isGivenKind(T_STRING) || !preg_match('/Action$/', $methodName->getContent())) {
+                continue;
+            }
+
+            $attributes = $tokensAnalyzer->getMethodAttributes($index);
+
+            // only update public methods
+            if (!(null === $attributes['visibility'] || T_PUBLIC === $attributes['visibility'])) {
+                continue;
+            }
+
+            // do not touch abstract methods
+            if (true === $attributes['abstract']) {
+                continue;
+            }
+
+            $methodStart = $tokens->getNextTokenOfKind($methodNameToken, ['{']);
+            $methodEnd   = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $methodStart);
+
+            if (null === $methodStart || null === $methodEnd) {
+                throw new \UnexpectedValueException(sprintf('Failed to find method end for method "%s"', $methodName->getContent()));
+            }
+
+            $this->processAction($tokens, $methodStart, $methodEnd);
+        }
+    }
+
+    private function processAction(Tokens $tokens, int $methodStart, int $methodEnd)
+    {
+        $functionAnalyzer = new FunctionAnalyzer();
+
+        $sequence   = $this->getSequence();
+        $candidates = $functionAnalyzer->findFunctionCallCandidates($tokens, $sequence, $methodStart, $methodEnd);
+
+        foreach ($candidates as $candidate) {
+            list($match, $openParenthesis, $closeParenthesis) = $candidate;
+
+            $this->processCandidate($tokens, $match, $openParenthesis, $closeParenthesis);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param Token[] $match
+     * @param int $openParenthesis
+     * @param int $closeParenthesis
+     */
+    private function processCandidate(Tokens $tokens, array $match, int $openParenthesis, int $closeParenthesis)
+    {
+        $indexes = array_keys($match);
+
+        // replace $this->getParam() with $request->get()
+        // we assume the $request was already added to the action method in ActionRequestFixer
+        $tokens->offsetSet($indexes[0], new Token([T_VARIABLE, '$request']));
+        $tokens->offsetSet($indexes[2], new Token([T_STRING, 'get']));
+    }
+}

--- a/src/CsFixer/Fixer/Controller/ControllerNamespaceFixer.php
+++ b/src/CsFixer/Fixer/Controller/ControllerNamespaceFixer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Pimcore\CsFixer\Fixer\Controller;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use Pimcore\CsFixer\Fixer\Traits\FixerNameTrait;
+use Pimcore\CsFixer\Fixer\Traits\SupportsControllerTrait;
+use Pimcore\CsFixer\Tokenizer\TokenInsertManipulator;
+
+final class ControllerNamespaceFixer extends AbstractFixer
+{
+    use FixerNameTrait;
+    use SupportsControllerTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Adds namespace to controllers without a namespace',
+            [new CodeSample('<?php namespace AppBundle\Controller')]
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_CLASS) && !$tokens->isTokenKindFound(T_NAMESPACE);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $newNamespaceIndex = null;
+        for ($index = 0; $index < $tokens->getSize() - 1; $index++) {
+            if ($tokens[$index]->isGivenKind(T_USE) || $tokens[$index]->isGivenKind(Token::getClassyTokenKinds())) {
+                $newNamespaceIndex = $index - 1;
+                break;
+            }
+        }
+
+        if (null === $newNamespaceIndex) {
+            return;
+        }
+
+        $namespace = [
+            new Token([T_NAMESPACE, 'namespace']),
+            new Token([T_WHITESPACE, ' ']),
+            new Token([T_STRING, 'AppBundle']),
+            new Token([T_NS_SEPARATOR, '\\']),
+            new Token([T_STRING, 'Controller']),
+            new Token(';'),
+        ];
+
+        $manipulator = new TokenInsertManipulator($tokens);
+        $manipulator->insertAtIndex($newNamespaceIndex, $namespace, 1, 1);
+    }
+}

--- a/src/CsFixer/Fixer/Traits/SupportsControllerTrait.php
+++ b/src/CsFixer/Fixer/Traits/SupportsControllerTrait.php
@@ -31,10 +31,15 @@ trait SupportsControllerTrait
         }
 
         $baseName = $file->getBasename($expectedExtension);
-        if (!preg_match('/Controller$/', $baseName)) {
+        if (!$this->isValidControllerName($baseName)) {
             return false;
         }
 
         return true;
+    }
+
+    public function isValidControllerName(string $name): bool
+    {
+        return (bool) preg_match('/Controller$/', $name);
     }
 }

--- a/src/CsFixer/Fixer/Traits/SupportsControllerTrait.php
+++ b/src/CsFixer/Fixer/Traits/SupportsControllerTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\CsFixer\Fixer\Traits;
+
+trait SupportsControllerTrait
+{
+    /**
+     * @inheritDoc
+     */
+    public function supports(\SplFileInfo $file)
+    {
+        $expectedExtension = '.php';
+
+        if (!substr($file->getFilename(), -strlen($expectedExtension)) === $expectedExtension) {
+            return false;
+        }
+
+        $baseName = $file->getBasename($expectedExtension);
+        if (!preg_match('/Controller$/', $baseName)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/CsFixer/Tokenizer/Controller/ActionAnalyzer.php
+++ b/src/CsFixer/Tokenizer/Controller/ActionAnalyzer.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\CsFixer\Tokenizer\Controller;
+
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+final class ActionAnalyzer
+{
+    public function isValidAction(Tokens $tokens, TokensAnalyzer $tokensAnalyzer, int $index, bool $allowAbstractMethods = false): bool
+    {
+        $methodNameToken = $tokens->getNextMeaningfulToken($index);
+        if (null === $methodNameToken) {
+            return false;
+        }
+
+        $methodName = $tokens[$methodNameToken];
+
+        // only update methods ending in Action
+        if (!$methodName->isGivenKind(T_STRING) || !preg_match('/Action$/', $methodName->getContent())) {
+            return false;
+        }
+
+        $attributes = $tokensAnalyzer->getMethodAttributes($index);
+
+        // only update public methods
+        if (!(null === $attributes['visibility'] || T_PUBLIC === $attributes['visibility'])) {
+            return false;
+        }
+
+        // do not touch abstract methods
+        if (!$allowAbstractMethods && true === $attributes['abstract']) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/CsFixer/Tokenizer/FunctionAnalyzer.php
+++ b/src/CsFixer/Tokenizer/FunctionAnalyzer.php
@@ -26,10 +26,12 @@ final class FunctionAnalyzer
      *
      * @param Tokens $tokens
      * @param array $sequence
+     * @param int|null $startIndex
+     * @param int|null $endIndex
      *
      * @return array
      */
-    public function findFunctionCallCandidates(Tokens $tokens, array $sequence): array
+    public function findFunctionCallCandidates(Tokens $tokens, array $sequence, int $startIndex = null, int $endIndex = null): array
     {
         if (count($sequence) === 0) {
             throw new \InvalidArgumentException('Sequence can\'t be empty!');
@@ -40,11 +42,19 @@ final class FunctionAnalyzer
             throw new \InvalidArgumentException('Sequence must end in opening parenthesis!');
         }
 
+        if (null === $startIndex) {
+            $startIndex = 0;
+        }
+
+        if (null === $endIndex) {
+            $endIndex = count($tokens) - 1;
+        }
+
         $candidates = [];
 
         $currIndex = 0;
         while (null !== $currIndex) {
-            $match = $tokens->findSequence($sequence, $currIndex, $tokens->count() - 1);
+            $match = $tokens->findSequence($sequence, $currIndex, $endIndex);
 
             // stop looping if didn't find any new matches
             if (null === $match) {
@@ -59,7 +69,7 @@ final class FunctionAnalyzer
             $candidates[] = [$match, $openParenthesis, $closeParenthesis];
 
             $currIndex = $openParenthesis + 1;
-            if ($currIndex >= count($tokens) - 1) {
+            if ($currIndex >= $endIndex) {
                 break;
             }
         }

--- a/src/CsFixer/Tokenizer/FunctionAnalyzer.php
+++ b/src/CsFixer/Tokenizer/FunctionAnalyzer.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\CsFixer\Tokenizer;
+
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class FunctionAnalyzer
+{
+    /**
+     * Finds function call candidates from from a sequence. Sequence must end in opening parenthesis!
+     *
+     * @param Tokens $tokens
+     * @param array $sequence
+     *
+     * @return array
+     */
+    public function findFunctionCallCandidates(Tokens $tokens, array $sequence): array
+    {
+        if (count($sequence) === 0) {
+            throw new \InvalidArgumentException('Sequence can\'t be empty!');
+        }
+
+        // add opening parenthesis if missing
+        if ($sequence[count($sequence) - 1] !== '(') {
+            throw new \InvalidArgumentException('Sequence must end in opening parenthesis!');
+        }
+
+        $candidates = [];
+
+        $currIndex = 0;
+        while (null !== $currIndex) {
+            $match = $tokens->findSequence($sequence, $currIndex, $tokens->count() - 1);
+
+            // stop looping if didn't find any new matches
+            if (null === $match) {
+                break;
+            }
+
+            $indexes         = array_keys($match);
+            $openParenthesis = array_pop($indexes);
+
+            $closeParenthesis = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis);
+
+            $candidates[] = [$match, $openParenthesis, $closeParenthesis];
+
+            $currIndex = $openParenthesis + 1;
+            if ($currIndex >= count($tokens) - 1) {
+                break;
+            }
+        }
+
+        return array_reverse($candidates);
+    }
+
+    /**
+     * Extracts tokens for a given argument
+     *
+     * @param Tokens $tokens
+     * @param array $arguments   The result of getArguments()
+     * @param int $argumentIndex The index of the argument
+     * @param bool $keepIndex
+     *
+     * @return array
+     */
+    public function extractArgumentTokens(Tokens $tokens, array $arguments, int $argumentIndex, bool $keepIndex = false): array
+    {
+        $indexes = array_keys($arguments);
+
+        if (!isset($indexes[$argumentIndex])) {
+            throw new \InvalidArgumentException(sprintf('Argument at index %d does not exist', $argumentIndex));
+        }
+
+        // arguments is an array indexed by start -> end
+        $startIndex = $indexes[$argumentIndex];
+        $endIndex   = $arguments[$startIndex];
+
+        $argumentTokens = [];
+        for ($i = $startIndex; $i <= $endIndex; $i++) {
+            // ignore leading whitespace tokens
+            if (empty($argumentTokens) && $tokens[$i]->isGivenKind(T_WHITESPACE)) {
+                continue;
+            }
+
+            if ($keepIndex) {
+                $argumentTokens[$i] = $tokens[$i];
+            } else {
+                $argumentTokens[] = $tokens[$i];
+            }
+        }
+
+        return $argumentTokens;
+    }
+}

--- a/src/CsFixer/Tokenizer/ImportsModifier.php
+++ b/src/CsFixer/Tokenizer/ImportsModifier.php
@@ -166,6 +166,7 @@ final class ImportsModifier
      * @param int $classStart
      *
      * @return array
+     *
      * @internal param Tokens $tokens
      */
     private function getImports(int $namespaceStart, int $classStart): array

--- a/src/CsFixer/Tokenizer/ImportsModifier.php
+++ b/src/CsFixer/Tokenizer/ImportsModifier.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\CsFixer\Tokenizer;
+
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class ImportsModifier
+{
+    /**
+     * @var Tokens
+     */
+    private $tokens;
+
+    public function __construct(Tokens $tokens)
+    {
+        $this->tokens = $tokens;
+    }
+
+    /**
+     * Add a class name import. classStart is used to find the best position inside the class' namespace
+     *
+     * @param int $classStart
+     * @param string $className
+     */
+    public function addImport(int $classStart, string $className)
+    {
+        $namespaceStart = $this->getNamespaceStart($classStart);
+        if (null === $namespaceStart) {
+            return;
+        }
+
+        $leadingNewline  = true;
+        $trailingNewline = false;
+
+        $importTokens = $this->createImportSequence($className);
+
+        $imports = $this->getImports($namespaceStart, $classStart);
+        if (0 === count($imports)) {
+            // add a trailing new line if it's a new use block
+            $trailingNewline = true;
+
+            $this->insertImport($namespaceStart, $importTokens, $leadingNewline, $trailingNewline);
+
+            return;
+        }
+
+        $newImportString = $this->stringifyTokenSequence($importTokens);
+
+        $hasImport      = false;
+        $insertPosition = $namespaceStart;
+
+        // try to find ordered insert position by comparing sequence string to existing imports
+        foreach ($imports as $import) {
+            $importString = $this->stringifyTokenSequence($import['import']);
+
+            // simple check if class was already imported. this will fail for group imports or other
+            // more sophicsticated notations, but handling all cases is overkill
+            if (false !== strpos($importString, $className)) {
+                $hasImport = true;
+                break;
+            }
+
+            $cmp = strcmp($newImportString, $importString);
+
+            if ($cmp >= 0) {
+                $insertPosition = $import['end'] + 1;
+            } elseif ($cmp < 0) {
+                break;
+            }
+        }
+
+        if (!$hasImport) {
+            $this->insertImport($insertPosition, $importTokens, $leadingNewline, $trailingNewline);
+        }
+    }
+
+    /**
+     * Inserts import sequence at given position and handles adding new lines before and after inserting.
+     *
+     * The difficulty is that we can't just add a \n token before after the sequence, but we need to edit an existing
+     * whitespace token if it is the previous/next one as consequent whitespace tokens lead to errors.
+     *
+     * @param int $index
+     * @param array $importTokens
+     * @param bool $leadingNewline
+     * @param bool $trailingNewline
+     */
+    private function insertImport(int $index, array $importTokens, bool $leadingNewline = true, bool $trailingNewline = false)
+    {
+        $this->tokens->insertAt($index, $importTokens);
+
+        if ($leadingNewline) {
+            $previousToken = $this->tokens[$index - 1];
+
+            if ($previousToken->isWhitespace()) {
+                $this->tokens->offsetSet(
+                    $index - 1,
+                    new Token([$previousToken->getId(), $previousToken->getContent() . "\n"])
+                );
+            } else {
+                $this->tokens->insertAt($index, new Token([T_WHITESPACE, "\n"]));
+            }
+        }
+
+        if ($trailingNewline) {
+            $endIndex  = $index + count($importTokens);
+            $nextToken = $this->tokens[$endIndex + 1];
+
+            if ($nextToken->isWhitespace()) {
+                $this->tokens->offsetSet(
+                    $endIndex + 1,
+                    new Token([$nextToken->getId(), "\n" . $nextToken->getContent()])
+                );
+            } else {
+                $this->tokens->insertAt($endIndex + 1, new Token([T_WHITESPACE, "\n"]));
+            }
+        }
+    }
+
+    /**
+     * Generate token use sequence for a class name
+     *
+     * @param string $className
+     *
+     * @return Token[]
+     */
+    private function createImportSequence(string $className): array
+    {
+        $tokens = Tokens::fromCode('<?php use ' . $className . ';');
+
+        // ignore first token which is <?php
+        $result = [];
+        for ($i = 1; $i < count($tokens); $i++) {
+            $result[] = $tokens[$i];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Namespace start is either after namespace declaration or after php open tag if
+     * no namespace is declared.
+     *
+     * @param int $classStart
+     *
+     * @return int|null
+     */
+    private function getNamespaceStart(int $classStart)
+    {
+        $namespaceStart = null;
+        for ($i = $classStart; $i >= 0; $i--) {
+            if ($this->tokens[$i]->isGivenKind(T_NAMESPACE)) {
+                $nextTokenIndex = $this->tokens->getNextTokenOfKind($i, [';', '{']);
+                if (null !== $nextTokenIndex) {
+                    $namespaceStart = $nextTokenIndex;
+                }
+
+                break;
+            }
+
+            if ($this->tokens[$i]->isGivenKind(T_OPEN_TAG)) {
+                $namespaceStart = $i + 1;
+                break;
+            }
+        }
+
+        return $namespaceStart;
+    }
+
+    /**
+     * Loads all import statements between namespace/php block start and class definition
+     *
+     * @param int $namespaceStart
+     * @param int $classStart
+     *
+     * @return array
+     * @internal param Tokens $tokens
+     */
+    private function getImports(int $namespaceStart, int $classStart): array
+    {
+        $imports = [];
+        for ($index = $namespaceStart; $index <= $classStart; ++$index) {
+            $token = $this->tokens[$index];
+
+            if ($token->isGivenKind(T_USE)) {
+                $importEnd = $this->tokens->getNextTokenOfKind($index, [';']);
+
+                $import = [];
+                for ($i = $index; $i <= $importEnd; $i++) {
+                    $import[] = $this->tokens[$i];
+                }
+
+                $imports[] = [
+                    'start'  => $index,
+                    'end'    => $importEnd,
+                    'import' => $import,
+                ];
+            }
+        }
+
+        return $imports;
+    }
+
+    /**
+     * Converts token sequence to string which will be used to determine sort order
+     *
+     * @param Token[] $tokens
+     *
+     * @return string
+     */
+    private function stringifyTokenSequence(array $tokens): string
+    {
+        $string = '';
+        foreach ($tokens as $token) {
+            if ($token instanceof Token) {
+                $string .= $token->getContent();
+            }
+        }
+
+        return trim($string);
+    }
+}

--- a/src/CsFixer/Tokenizer/TokenInsertManipulator.php
+++ b/src/CsFixer/Tokenizer/TokenInsertManipulator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\CsFixer\Tokenizer;
+
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+class TokenInsertManipulator
+{
+    /**
+     * @var Tokens
+     */
+    private $tokens;
+
+    public function __construct(Tokens $tokens)
+    {
+        $this->tokens = $tokens;
+    }
+
+    /**
+     * Inserts sequence at given position and handles adding new lines before and after inserting.
+     *
+     * The difficulty is that we can't just add a \n token before after the sequence, but we need to edit an existing
+     * whitespace token if it is the previous/next one as consequent whitespace tokens lead to errors.
+     *
+     * @param int $index
+     * @param array $tokens
+     * @param int $leadingNewlines
+     * @param int $trailingNewlines
+     */
+    public function insertAtIndex(int $index, array $tokens, int $leadingNewlines = 0, int $trailingNewlines = 0)
+    {
+        $this->tokens->insertAt($index, $tokens);
+
+        if ($leadingNewlines > 0) {
+            $leadingContent = str_repeat("\n", $leadingNewlines);
+
+            $previousToken = $this->tokens[$index - 1];
+
+            if ($previousToken->isWhitespace()) {
+                $this->tokens->offsetSet(
+                    $index - 1,
+                    new Token([$previousToken->getId(), $previousToken->getContent() . $leadingContent])
+                );
+            } else {
+                $this->tokens->insertAt($index, new Token([T_WHITESPACE, $leadingContent]));
+            }
+        }
+
+        if ($trailingNewlines > 0) {
+            $trailingContent = str_repeat("\n", $trailingNewlines);
+
+            $endIndex  = $index + count($tokens);
+            $nextToken = $this->tokens[$endIndex + 1];
+
+            if ($nextToken->isWhitespace()) {
+                $this->tokens->offsetSet(
+                    $endIndex + 1,
+                    new Token([$nextToken->getId(), $trailingContent . $nextToken->getContent()])
+                );
+            } else {
+                $this->tokens->insertAt($endIndex + 1, new Token([T_WHITESPACE, $trailingContent]));
+            }
+        }
+    }
+}

--- a/src/CsFixer/Tokenizer/TokenInsertManipulator.php
+++ b/src/CsFixer/Tokenizer/TokenInsertManipulator.php
@@ -20,7 +20,7 @@ namespace Pimcore\CsFixer\Tokenizer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
-class TokenInsertManipulator
+final class TokenInsertManipulator
 {
     /**
      * @var Tokens

--- a/tests/CsFixer/Fixer/Controller/AbstractControllerFixerTestCase.php
+++ b/tests/CsFixer/Fixer/Controller/AbstractControllerFixerTestCase.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace Pimcore\Tests\CsFixer\Fixer\Controller;
+
+use Pimcore\Tests\CsFixer\AbstractFixerTestCase;
+
+abstract class AbstractControllerFixerTestCase extends AbstractFixerTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getTestFile($filename = __FILE__)
+    {
+        return new \SplFileInfo('src/AppBundle/Controller/TestController.php');
+    }
+}

--- a/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
@@ -20,47 +20,6 @@ class ActionRequestFixerTest extends AbstractControllerFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function proddvideFixCases()
-    {
-        $argumentActionInput = <<<'EOF'
-<?php
-
-namespace AppBundle\Controller;
-
-use Pimcore\Controller\FrontendController;
-
-class TestController extends FrontendController
-{
-    public function fooAction($foo, $bar)
-    {
-    }
-}
-EOF;
-
-        $argumentActionExpected = <<<'EOF'
-<?php
-
-namespace AppBundle\Controller;
-
-use Pimcore\Controller\FrontendController
-use Symfony\Component\HttpFoundation\Request;
-
-class TestController extends FrontendController
-{
-    public function fooAction(Request $request, $foo, $bar)
-    {
-    }
-}
-EOF;
-
-        return [
-            [
-                $argumentActionExpected,
-                $argumentActionInput
-            ]
-        ];
-    }
-
     public function provideFixCases()
     {
         $emptyActionInput = <<<'EOF'

--- a/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
@@ -154,6 +154,30 @@ class TestController extends FrontendController
 }
 EOF;
 
+        $noNamespaceNoUseInput = <<<'EOF'
+<?php
+
+class TestController
+{
+    public function fooAction($foo, $bar)
+    {
+    }
+}
+EOF;
+
+        $noNamespaceNoUseExpected = <<<'EOF'
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+
+class TestController
+{
+    public function fooAction(Request $request, $foo, $bar)
+    {
+    }
+}
+EOF;
+
         $alreadyExistingNamespaceIgnoredInput = <<<'EOF'
 <?php
 
@@ -230,6 +254,10 @@ EOF;
             [
                 $noNamespaceExpected,
                 $noNamespaceInput
+            ],
+            [
+                $noNamespaceNoUseExpected,
+                $noNamespaceNoUseInput,
             ],
             [
                 $alreadyExistingNamespaceIgnoredExpected,

--- a/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Pimcore\Tests\CsFixer\Fixer\Controller;
+
+use Pimcore\CsFixer\Fixer\Controller\ActionRequestFixer;
+
+/**
+ * @covers ActionRequestFixer
+ */
+class ActionRequestFixerTest extends AbstractControllerFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param $expected
+     * @param null $input
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function proddvideFixCases()
+    {
+        $argumentActionInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+    public function fooAction($foo, $bar)
+    {
+    }
+}
+EOF;
+
+        $argumentActionExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController
+use Symfony\Component\HttpFoundation\Request;
+
+class TestController extends FrontendController
+{
+    public function fooAction(Request $request, $foo, $bar)
+    {
+    }
+}
+EOF;
+
+        return [
+            [
+                $argumentActionExpected,
+                $argumentActionInput
+            ]
+        ];
+    }
+
+    public function provideFixCases()
+    {
+        $emptyActionInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+use Xyz\Foo\Foo;
+
+class TestController extends FrontendController
+{
+    public function fooAction()
+    {
+    }
+}
+EOF;
+
+        $emptyActionExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+use Symfony\Component\HttpFoundation\Request;
+use Xyz\Foo\Foo;
+
+class TestController extends FrontendController
+{
+    public function fooAction(Request $request)
+    {
+    }
+}
+EOF;
+
+        $argumentActionInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+    public function fooAction($foo, $bar)
+    {
+    }
+}
+EOF;
+
+        $argumentActionExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+use Symfony\Component\HttpFoundation\Request;
+
+class TestController extends FrontendController
+{
+    public function fooAction(Request $request, $foo, $bar)
+    {
+    }
+}
+EOF;
+
+        $noNamespaceInput = <<<'EOF'
+<?php
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+    public function fooAction($foo, $bar)
+    {
+    }
+}
+EOF;
+
+        $noNamespaceExpected = <<<'EOF'
+<?php
+
+use Pimcore\Controller\FrontendController;
+use Symfony\Component\HttpFoundation\Request;
+
+class TestController extends FrontendController
+{
+    public function fooAction(Request $request, $foo, $bar)
+    {
+    }
+}
+EOF;
+
+        $alreadyExistingNamespaceIgnoredInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+use Symfony\Component\HttpFoundation\Request;
+
+class TestController extends FrontendController
+{
+    public function fooAction()
+    {
+    }
+}
+EOF;
+
+        $alreadyExistingNamespaceIgnoredExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+use Symfony\Component\HttpFoundation\Request;
+
+class TestController extends FrontendController
+{
+    public function fooAction(Request $request)
+    {
+    }
+}
+EOF;
+
+        $alreadyExistingArgumentIgnored = $alreadyExistingNamespaceIgnoredExpected;
+
+        $privateActionIgnored = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+    private function fooAction()
+    {
+    }
+}
+EOF;
+
+        $nonActionMethodIgnored = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+    public function foo()
+    {
+    }
+}
+EOF;
+
+        return [
+            [
+                $emptyActionExpected,
+                $emptyActionInput
+            ],
+            [
+                $argumentActionExpected,
+                $argumentActionInput
+            ],
+            [
+                $noNamespaceExpected,
+                $noNamespaceInput
+            ],
+            [
+                $alreadyExistingNamespaceIgnoredExpected,
+                $alreadyExistingNamespaceIgnoredInput
+            ],
+            [
+                $alreadyExistingArgumentIgnored,
+                null
+            ],
+            [
+                $privateActionIgnored,
+                null
+            ],
+            [
+                $nonActionMethodIgnored,
+                null
+            ],
+        ];
+    }
+}

--- a/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
@@ -242,6 +242,19 @@ class TestController extends FrontendController
 }
 EOF;
 
+        $nonControllerClassIgnored = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestPresenter
+{
+    public function fooAction()
+    {
+    }
+}
+EOF;
+
         return [
             [
                 $emptyActionExpected,
@@ -273,6 +286,10 @@ EOF;
             ],
             [
                 $nonActionMethodIgnored,
+                null
+            ],
+            [
+                $nonControllerClassIgnored,
                 null
             ],
         ];

--- a/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ActionRequestFixerTest.php
@@ -154,6 +154,34 @@ class TestController extends FrontendController
 }
 EOF;
 
+        $noUseInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController
+{
+    public function fooAction($foo, $bar)
+    {
+    }
+}
+EOF;
+
+        $noUseExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class TestController
+{
+    public function fooAction(Request $request, $foo, $bar)
+    {
+    }
+}
+EOF;
+
         $noNamespaceNoUseInput = <<<'EOF'
 <?php
 
@@ -267,6 +295,10 @@ EOF;
             [
                 $noNamespaceExpected,
                 $noNamespaceInput
+            ],
+            [
+                $noUseExpected,
+                $noUseInput
             ],
             [
                 $noNamespaceNoUseExpected,

--- a/tests/CsFixer/Fixer/Controller/ControllerBaseClassFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ControllerBaseClassFixerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Pimcore\Tests\CsFixer\Fixer\Controller;
+
+use Pimcore\CsFixer\Fixer\Controller\ControllerBaseClassFixer;
+
+/**
+ * @covers ControllerBaseClassFixer
+ */
+class ControllerBaseClassFixerTest extends AbstractControllerFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param $expected
+     * @param null $input
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        $simpleControllerInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController extends Website_Controller_Action
+{
+}
+EOF;
+
+        $simpleControllerExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+// class TestController extends Website_Controller_Action
+class TestController extends FrontendController
+{
+}
+EOF;
+
+        $finalControllerInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+final class TestController extends Website_Controller_Action
+{
+}
+EOF;
+
+        $finalControllerExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+// final class TestController extends Website_Controller_Action
+final class TestController extends FrontendController
+{
+}
+EOF;
+
+        $noNamespaceInput = <<<'EOF'
+<?php
+
+class TestController extends Website_Controller_Action
+{
+}
+EOF;
+
+        $noNamespaceExpected = <<<'EOF'
+<?php
+
+use Pimcore\Controller\FrontendController;
+
+// class TestController extends Website_Controller_Action
+class TestController extends FrontendController
+{
+}
+EOF;
+
+        $simpleControllerInlineInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController extends Website_Controller_Action {}
+EOF;
+
+        $simpleControllerInlineExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+// class TestController extends Website_Controller_Action
+class TestController extends FrontendController {}
+EOF;
+
+        $interfaceControllerInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController extends Website_Controller_Action implements FooInterface, BarInterface
+{
+}
+EOF;
+
+        $interfaceControllerExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+// class TestController extends Website_Controller_Action implements FooInterface, BarInterface
+class TestController extends FrontendController implements FooInterface, BarInterface
+{
+}
+EOF;
+
+        $multilineControllerInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+final class TestController
+    extends Website_Controller_Action
+    implements
+        FooInterface,
+        BarInterface
+{
+}
+EOF;
+
+        $multilineControllerExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+// final class TestController extends Website_Controller_Action implements FooInterface, BarInterface
+final class TestController
+    extends FrontendController
+    implements
+        FooInterface,
+        BarInterface
+{
+}
+EOF;
+
+        $nonControllerClassIgnored = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestPresenter extends Website_Controller_Action
+{
+    public function fooAction()
+    {
+    }
+}
+EOF;
+
+        $alreadyMigratedIgnored = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+}
+EOF;
+
+        return [
+            [
+                $simpleControllerExpected,
+                $simpleControllerInput
+            ],
+            [
+                $finalControllerExpected,
+                $finalControllerInput
+            ],
+            [
+                $noNamespaceExpected,
+                $noNamespaceInput
+            ],
+            [
+                $simpleControllerInlineExpected,
+                $simpleControllerInlineInput
+            ],
+            [
+                $interfaceControllerExpected,
+                $interfaceControllerInput
+            ],
+            [
+                $multilineControllerExpected,
+                $multilineControllerInput
+            ],
+            [
+                $nonControllerClassIgnored,
+                null
+            ],
+            [
+                $alreadyMigratedIgnored,
+                null
+            ]
+        ];
+    }
+}

--- a/tests/CsFixer/Fixer/Controller/ControllerGetParamFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ControllerGetParamFixerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Pimcore\Tests\CsFixer\Fixer\Controller;
+
+use Pimcore\CsFixer\Fixer\Controller\ControllerGetParamFixer;
+
+/**
+ * @covers ControllerGetParamFixer
+ */
+class ControllerGetParamFixerTest extends AbstractControllerFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        $insideActionInput = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController
+{
+    public function fooAction(Request $request)
+    {
+        $anotherValue = 123;
+    
+        $foo = $this->getParam('foo');
+        $bar = $this->getParam('bar', 'default value');
+        $baz = $this->getParam('baz', $anotherValue);
+        $inga = $this->getParam('inga', $this->getAnotherValue());
+    }
+    
+    private function getAnotherValue()
+    {
+        return 'bazinga';
+    }
+}
+EOF;
+
+        $insideActionExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController
+{
+    public function fooAction(Request $request)
+    {
+        $anotherValue = 123;
+    
+        $foo = $request->get('foo');
+        $bar = $request->get('bar', 'default value');
+        $baz = $request->get('baz', $anotherValue);
+        $inga = $request->get('inga', $this->getAnotherValue());
+    }
+    
+    private function getAnotherValue()
+    {
+        return 'bazinga';
+    }
+}
+EOF;
+
+        $alreadyMigratedIgnored = $insideActionExpected;
+
+        $insideOtherMethodIgnored = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController
+{   
+    public function getAValue()
+    {
+        $foo = $this->getParam('foo');
+    }
+
+    private function getAnotherValue()
+    {
+        $bar = $this->getParam('bar');
+    }
+}
+EOF;
+
+        $outsideClassScopeIgnored = <<<'EOF'
+<?php
+
+$this->getParam('foo');
+EOF;
+
+        return [
+            [
+                $insideActionExpected,
+                $insideActionInput
+            ],
+            [
+                $alreadyMigratedIgnored,
+                null
+            ],
+            [
+                $insideOtherMethodIgnored,
+                null
+            ],
+            [
+                $outsideClassScopeIgnored,
+                null
+            ]
+        ];
+    }
+}

--- a/tests/CsFixer/Fixer/Controller/ControllerNamespaceFixerTest.php
+++ b/tests/CsFixer/Fixer/Controller/ControllerNamespaceFixerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Pimcore\Tests\CsFixer\Fixer\Controller;
+
+use Pimcore\CsFixer\Fixer\Controller\ControllerNamespaceFixer;
+
+/**
+ * @covers ControllerNamespaceFixer
+ */
+class ControllerNamespaceFixerTest extends AbstractControllerFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param $expected
+     * @param null $input
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        $simpleControllerInput = <<<'EOF'
+<?php
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+}
+EOF;
+
+        $simpleControllerExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+use Pimcore\Controller\FrontendController;
+
+class TestController extends FrontendController
+{
+}
+EOF;
+
+        $noUseInput = <<<'EOF'
+<?php
+
+class TestController
+{
+}
+EOF;
+
+        $noUseExpected = <<<'EOF'
+<?php
+
+namespace AppBundle\Controller;
+
+class TestController
+{
+}
+EOF;
+
+        $differentNamespaceIgnored = <<<'EOF'
+<?php
+
+namespace AppBundle\Foo;
+
+class TestController
+{
+}
+EOF;
+
+        $alreadyNamespacedIgnored = $simpleControllerExpected;
+
+        return [
+            [
+                $simpleControllerExpected,
+                $simpleControllerInput
+            ],
+            [
+                $noUseExpected,
+                $noUseInput
+            ],
+            [
+                $differentNamespaceIgnored,
+                null
+            ],
+            [
+                $alreadyNamespacedIgnored,
+                null
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #5 

- [x] Add request type hint `fooAction(Request $request)` 
- [x] Change `$this->getParam()` to `$request->get()`
- [x] Add controller namespace and extend `FrontendController`